### PR TITLE
[init] YDS에 없는 색 추가

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,10 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+
+    <!-- Custom Colors -->
+    <color name="black_131313">#131313</color>
+    <color name="gray_343434">#343434</color>
+    <color name="purple_816dec">#816DEC</color>
+    <color name="red_ff5252">#FF5252</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,4 @@
     <!-- Custom Colors -->
     <color name="black_131313">#131313</color>
     <color name="gray_343434">#343434</color>
-    <color name="purple_816dec">#816DEC</color>
-    <color name="red_ff5252">#FF5252</color>
 </resources>


### PR DESCRIPTION
- 배경색이 #000000이 아니라 #131313이니, 참고하여 만들어둔 색 리소스 사용해주시면 됩니다.
<img width="457" alt="스크린샷 2024-01-30 오후 5 28 14" src="https://github.com/yourssu-rookies/unscramble-android-2/assets/108331578/27aec246-350b-4dbf-a8ae-01ef370c5597">

- 게임 시작 뷰에도 YDS에 정의되지 않은 색이 있는 것 같아 추가하였습니다.
<img width="394" alt="스크린샷 2024-01-30 오후 5 24 33" src="https://github.com/yourssu-rookies/unscramble-android-2/assets/108331578/23348d08-1add-4c7e-b01e-86b940f2b081">

Resolved: #11 